### PR TITLE
Added back button to 404 page and echoes broken link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,13 +19,15 @@
       href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/10.0.0/styles/default.min.css"
     />
     <script>
-      ;(function() {
-        const redirect = sessionStorage.redirect
-        delete sessionStorage.redirect
-        if (redirect && redirect !== location.href) {
-          history.replaceState(null, null, redirect)
-        }
-      })()
+      // KRM remove this to allow the back button to be used on the 404 page?
+      // ;(function() {
+      //   const redirect = sessionStorage.redirect
+      //   delete sessionStorage.redirect
+      //   
+      //   if (redirect && redirect !== location.href) {
+      //     history.replaceState(null, null, redirect) 
+      //   }
+      // })()
     </script>
 <script
 type="text/javascript"

--- a/src/App.vue
+++ b/src/App.vue
@@ -118,16 +118,12 @@ import BackToTop from '@/components/BackToTop'
 import Sidebar from '@/components/Sidebar'
 import NotificationContainer from '@/components/NotificationContainer'
 
-// KRM
 import ui from '@/js/ui'
-
-// import BreadCrumbs from '@/components/BreadCrumbs'
 
 export default {
   name: 'App',
 
   components: {
-    // BreadCrumbs,
     BackToTop,
     Sidebar,
     NotificationContainer,
@@ -177,7 +173,6 @@ export default {
 
   computed: {
     breadcrumbs() {
-      // KRM TODO Remove last item from breadcrumbs as we don't need it.
       return this.$store.state.breadcrumbs
     },
   },
@@ -192,6 +187,7 @@ export default {
       this.window.width = window.innerWidth
       this.window.height = window.innerHeight
     },
+
   },
 
   watch: {

--- a/src/assets/custom.css
+++ b/src/assets/custom.css
@@ -401,19 +401,6 @@ pre {
     /* max-width: 100%; */
 }
 
-/* @media only screen and (max-width: 960px) {
-
-    .image-box img {
-       max-width: 250px;
-    }
-}
-
-@media only screen and (max-width: 600px) {
-    .image-box img {
-       max-width: 250px;
-    }
-}  */
-
 @media only screen and (max-width: 300px) {
     .image-box img {
        max-width: 100%;

--- a/src/components/BrokenLink.vue
+++ b/src/components/BrokenLink.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-container>
+    <v-row>
+      <v-col>
+        <p>The page that you've requested:</p>
+        <h4>{{ lastURL }}</h4>
+        <br/>
+        <p>
+          does not exist.
+          Please use the "back" button on your browser to return to where you were, or start again using the 
+          links in the menu bar.
+        </p>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: 'BrokenLink',
+
+  computed: {
+    lastURL() {
+      return this.$store.getters.getLastURL
+    }
+  },
+}
+</script>
+
+<style scoped></style>

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1,39 +1,5 @@
 export default {
 
-  // KRM
-  // moveTabNames: function () {
-  //   let tabGroups = document.querySelectorAll('.container .tabs2')
-  //   tabGroups.forEach((group, groupIndex) => {
-  //     group.id = 'g' + groupIndex
-
-  //     if (!group.querySelector('.tab2menu')) {
-  //       let menu = document.createElement('div')
-  //       menu.classList.add('tab2menu')
-  //       menu.id = 'g' + groupIndex + 'menu'
-
-  //       let firstPanel = group.firstElementChild
-  //       firstPanel.insertAdjacentElement('beforebegin', menu)
-
-  //       group.querySelectorAll('.tab2').forEach((t, tabIndex) => {
-  //         t.id = 'g' + groupIndex + 't' + tabIndex + 'tab'
-
-  //         let tabName = t.querySelector('.tab2name')
-  //         tabName.id = 'g' + groupIndex + 't' + tabIndex
-
-  //         menu.appendChild(tabName)
-  //       })
-
-  //       let menuSpacer = document.createElement('div')
-  //       menuSpacer.classList.add('tab2spacer')
-
-  //       firstPanel.classList.add('active')
-  //       firstPanel.classList.remove('inactive')
-  //       menu.querySelector('#g' + groupIndex + 't0').classList.add('active')
-
-  //     }
-  //   })
-  // },
-
   addClickHandlerToggles: function () {
     // Event capture for the "toggle" class:
     let headers = document.querySelectorAll('header, .header-left')

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from 'vue-router'
 import Home from '@/views/Home.vue'
 
 import store from '@/store'
+import { mdiSortReverseVariant } from '@mdi/js'
 
 
 Vue.use(VueRouter)
@@ -80,12 +81,15 @@ const routes = [
   },
   {
     path: '*',
-    redirect: { name: '404', params: { resource: 'page' } },
+    redirect: {
+      name: '404',
+      params: { resource: 'page' },
+    },
   },
 ]
 
 const skipPaths = [
-  // '/v0.4.0/howto/actions',
+  // KRM Placeholder for views to skip in the breadcrumbs
 ]
 const createRouter = () => {
   return new VueRouter({
@@ -120,8 +124,10 @@ const createRouter = () => {
 
 const router = createRouter()
 
-// Breadcrumb calculation KRM
+
 router.beforeEach((to, from, next) => {
+
+  // KRM Breadcrumb calculation
   let items = [
     {
       text: 'home',
@@ -129,7 +135,6 @@ router.beforeEach((to, from, next) => {
       href: '/',
     },
   ]
-
   if (to.name === 'Home') {
     items[0].disabled = true
   } else if (
@@ -145,7 +150,7 @@ router.beforeEach((to, from, next) => {
       href: to.path,
     })
   } else if (
-    to.name === 'APIReferencePage' || 
+    to.name === 'APIReferencePage' ||
     to.name === 'APIReference'
   ) {
     let toPath = to.path
@@ -195,9 +200,9 @@ router.beforeEach((to, from, next) => {
       }
     })
   }
-
   // KRM reversing order of breadcrumbs so that we can truncate the list on the left hand side.
   store.commit('setBreadcrumbs', items.slice().reverse())
+  store.commit('updateLastURL', to.path)
 
   next()
 })

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -12,6 +12,7 @@ export default new Vuex.Store({
     transitionDelay: 300, // This number has to be higher than page transition
     pageContentChanged: false,
     breadcrumbs: [],
+    lastURL: ['','',''],
   },
   getters: {
     getSidebarOpen: state => {
@@ -29,6 +30,9 @@ export default new Vuex.Store({
     hasRoute: state => name => {
       return state.dynamicRoutes.filter(entry => entry.name === name).length > 0
     },
+    getLastURL: state => {
+      return state.lastURL[1]
+    }
   },
   mutations: {
     setSidebarOpen: (state, value) => {
@@ -42,6 +46,11 @@ export default new Vuex.Store({
     },
     setBreadcrumbs: (state, value) => {
       state.breadcrumbs = value
+    },
+    updateLastURL: (state, value) => {
+      state.lastURL[0] = state.lastURL[1]
+      state.lastURL[1] = state.lastURL[2]
+      state.lastURL[2] = value
     },
   },
   modules: { notifications },

--- a/src/views/NotFound.vue
+++ b/src/views/NotFound.vue
@@ -3,13 +3,21 @@
     <v-row>
       <v-col>
         <h1>Oops!</h1>
-        <h3>The page you are looking for is not here.</h3>
+        <BrokenLink />
         <router-link to="/">Back to the home page</router-link>
       </v-col>
     </v-row>
+  
   </v-container>
 </template>
 
 <script>
-export default {}
+import BrokenLink from '@/components/BrokenLink'
+
+export default {
+  name: 'About',
+  components: {
+    BrokenLink,
+  },
+}
 </script>


### PR DESCRIPTION
The 404 page for broken links has changed:
- allows use of the back button to return to a safe page, instead of having to re-navigate from the home page each time;
- echoes the link that's not working so that users can report it / see typing errors more easily.

Closes #9 